### PR TITLE
use application/javascript to be 'X-Content-Type-Options nosniff' compliant

### DIFF
--- a/swagger-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
+++ b/swagger-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
@@ -28,8 +28,12 @@ public class StaticResourcesService {
             buffer.lines().forEach(stringWriter::write);
 
             String response = stringWriter.toString();
-            if(response!=null && !response.isEmpty()){
-                return Response.ok(response).build();
+            if (response != null && !response.isEmpty()) {
+                Response.ResponseBuilder ret = Response.ok(response);
+                if (path.endsWith(".js")) {
+                    ret = ret.type("application/javascript");
+                }
+                return ret.build();
             }
         } catch (IOException ex) {
             log.severe(ex.getMessage());


### PR DESCRIPTION
Hi All
If we use, e.g, nginx with the header X-Content-Type-Options nosniff, when we get our js files (as text/plain) we get a "mime type ('text/plain') is not executable" error.
This PR aims so send the type as "application/javascript" when we return a js file
(context on the header: https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff)