### PR TITLE
Enforce java 11 version to compile and run Helidon samples

### DIFF
--- a/openapi-examples/helidon-basic-example/README.md
+++ b/openapi-examples/helidon-basic-example/README.md
@@ -4,6 +4,11 @@
 
 This is a very basic helidon application to demonstrate the OpenApi extensions.
 
+## Requirement
+
+To build the example, you need JDK 11 and Maven 3.8.4.
+
+
 ## Running the example
 
 Using maven, you can start this application this way:
@@ -13,3 +18,5 @@ Using maven, you can start this application this way:
 ```
 
 You can then go to http://localhost:8080/openapi-ui/ 
+
+Press `ctrl+C` to stop the application.

--- a/openapi-examples/helidon-basic-example/pom.xml
+++ b/openapi-examples/helidon-basic-example/pom.xml
@@ -18,6 +18,8 @@
 
     <properties>
         <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencies>

--- a/openapi-examples/helidon-features-example/README.md
+++ b/openapi-examples/helidon-features-example/README.md
@@ -4,6 +4,10 @@
 
 This is a basic helidon application to demonstrate several features of the OpenApi extensions with Helidon.
 
+## Requirement
+
+To build the example, you need JDK 11 and Maven 3.8.4.
+
 ## Presentation
 
 Based on Helidon MP quickstart application, this example uses Openapi UI extension features. It exposes the greeting
@@ -20,3 +24,5 @@ Using maven, you can start this application this way:
 ```
 
 You can then go to http://localhost:8080/myopenapi/openapi-ui/ 
+
+Press `ctrl+C` to stop the application.

--- a/openapi-examples/helidon-features-example/pom.xml
+++ b/openapi-examples/helidon-features-example/pom.xml
@@ -18,6 +18,8 @@
 
     <properties>
         <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Java 11 enforcement + Documentation improvement

fix https://github.com/microprofile-extensions/openapi-ext/issues/44