### PR TITLE
Update dependencies to use microprofile 5

### DIFF
--- a/openapi-examples/basic-example/pom.xml
+++ b/openapi-examples/basic-example/pom.xml
@@ -43,7 +43,7 @@
             </activation>
             
             <properties>
-                <thorntail.version>2.6.0.Final</thorntail.version>
+                <thorntail.version>2.7.0.Final</thorntail.version>
                 <thorntail.configDir>${basedir}${file.separator}src${file.separator}main${file.separator}resources</thorntail.configDir>
             </properties>
             
@@ -143,8 +143,8 @@
             
             <properties>
                 <!-- payara-micro properties -->
-                <payara-micro.maven.version>1.0.3</payara-micro.maven.version>
-                <payara-micro.version>5.194</payara-micro.version>
+                <payara-micro.maven.version>1.4.0</payara-micro.maven.version>
+                <payara-micro.version>5.2022.3</payara-micro.version>
                 <payara-micro.installDir>${java.io.tmpdir}${file.separator}${project.artifactId}${file.separator}payara-micro</payara-micro.installDir>
                 <payara-micro.configDir>${basedir}${file.separator}src${file.separator}main${file.separator}payara-micro${file.separator}config</payara-micro.configDir>
                 <payara-micro.logsDir>${payara-micro.installDir}${file.separator}logs</payara-micro.logsDir>
@@ -161,7 +161,7 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
-            
+
             <dependencies>
                 <!-- Payara -->
                 <dependency>
@@ -185,6 +185,13 @@
                                 <version>${payara-micro.version}</version>
                             </artifactItem>
                             <payaraVersion>${payara-micro.version}</payaraVersion>
+                            <!-- Added due to: -->
+                            <!-- https://stackoverflow.com/questions/18747134/getting-cant-assign-requested-address-java-net-socketexception-using-ehcache -->
+                            <javaCommandLineOptions>
+                                <option>
+                                    <value>-Djava.net.preferIPv4Stack=true</value>
+                                </option>
+                            </javaCommandLineOptions>
                             <commandLineOptions>
                                 <option>
                                     <key>--rootdir</key>
@@ -232,13 +239,13 @@
             <properties>
                 <log.name>org.microprofileext.config</log.name>
                 <log.level>FINEST</log.level>
-                <openliberty.version>19.0.0.11</openliberty.version>
+                <openliberty.version>22.0.0.10</openliberty.version>
                 <openliberty.http.port>8080</openliberty.http.port>
                 <openliberty.https.port>8443</openliberty.https.port>
                 <openliberty.installDir>${java.io.tmpdir}${file.separator}${project.artifactId}${file.separator}openliberty</openliberty.installDir>
                 <openliberty.configDir>${basedir}${file.separator}src${file.separator}main${file.separator}openliberty${file.separator}config</openliberty.configDir>
                 <openliberty.logsDir>${openliberty.installDir}${file.separator}wlp${file.separator}usr${file.separator}servers${file.separator}defaultServer${file.separator}logs</openliberty.logsDir>
-                <openliberty.maven.version>2.7</openliberty.maven.version>
+                <openliberty.maven.version>3.0.M1</openliberty.maven.version>
             </properties>
             
             <build>

--- a/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/ApplicationConfig.java
+++ b/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/ApplicationConfig.java
@@ -1,7 +1,7 @@
 package org.microprofileext.openapi.example;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.info.Contact;
 import org.eclipse.microprofile.openapi.annotations.info.Info;

--- a/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/PersonProducer.java
+++ b/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/PersonProducer.java
@@ -1,61 +1,54 @@
 package org.microprofileext.openapi.example;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
+import java.util.stream.Collectors;
 
 /**
  * Creating some test data
+ *
  * @author Phillip Kruger (phillip.kruger@phillip-kruger.com)
  */
+
 @ApplicationScoped
 public class PersonProducer {
-    
-    @Produces
-    public Map<Integer,Person> produceAllPeople(){
-        Map<Integer,Person> m = new HashMap<>();
-        
-        JsonArray jsonPeople = getJsonData();
-        
-        for(JsonValue jsonPerson : jsonPeople){
-            Person p = toPerson((JsonObject)jsonPerson);
-            m.put(p.getId(), p);
-        }
-        
-        return m;
+
+  @Produces
+  public Map<Integer, Person> produceAllPeople() {
+    return getJsonData().stream()
+                        .map(e -> toPerson((JsonObject) e))
+                        .collect(Collectors.toMap(Person::getId, p -> p));
+  }
+
+  private Person toPerson(JsonObject jsonObject) {
+    Person p = new Person();
+    p.setId(jsonObject.getInt("id"));
+    p.setFirstName(jsonObject.getString("first_name"));
+    p.setLastName(jsonObject.getString("last_name"));
+    p.setEmail(jsonObject.getString("email"));
+    p.setGender(Gender.valueOf(jsonObject.getString("gender")));
+    p.setIPAddress(jsonObject.getString("ip_address"));
+    return p;
+  }
+
+  private JsonArray getJsonData() {
+    try (InputStream is = readSampleData()) {
+      JsonReader reader = Json.createReader(is);
+      return reader.readArray();
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
     }
-    
-    private Person toPerson(JsonObject jsonObject){
-        Person p = new Person();
-        p.setId(jsonObject.getInt("id"));
-        p.setFirstName(jsonObject.getString("first_name"));
-        p.setLastName(jsonObject.getString("last_name"));
-        p.setEmail(jsonObject.getString("email"));
-        p.setGender(Gender.valueOf(jsonObject.getString("gender")));
-        p.setIPAddress(jsonObject.getString("ip_address"));
-        return p;
-    }
-    
-    private JsonArray getJsonData(){
-        try(InputStream is = readSampleData()){
-            JsonReader reader = Json.createReader(is);
-            return reader.readArray();
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-    
-    private InputStream readSampleData(){
-        ClassLoader classLoader = getClass().getClassLoader();
-        return classLoader.getResourceAsStream("examples/data.json");
-    }
-    
+  }
+
+  private InputStream readSampleData() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    return classLoader.getResourceAsStream("examples/data.json");
+  }
 }

--- a/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/PersonService.java
+++ b/openapi-examples/basic-example/src/main/java/org/microprofileext/openapi/example/PersonService.java
@@ -1,15 +1,15 @@
 package org.microprofileext.openapi.example;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Map;
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import lombok.extern.java.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;

--- a/openapi-examples/basic-example/src/main/openliberty/config/server.xml
+++ b/openapi-examples/basic-example/src/main/openliberty/config/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>microProfile-1.4</feature>
+        <feature>microProfile-5.0</feature>
     </featureManager>
     
     <httpEndpoint id="defaultHttpEndpoint"

--- a/openapi-examples/basic-example/src/main/webapp/WEB-INF/beans.xml
+++ b/openapi-examples/basic-example/src/main/webapp/WEB-INF/beans.xml
@@ -2,6 +2,6 @@
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
     
 </beans>

--- a/openapi-examples/helidon-basic-example/src/main/java/org/microprofileext/openapi/helidon/basic/example/GreetResource.java
+++ b/openapi-examples/helidon-basic-example/src/main/java/org/microprofileext/openapi/helidon/basic/example/GreetResource.java
@@ -16,19 +16,19 @@
 
 package org.microprofileext.openapi.helidon.basic.example;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
-import javax.json.JsonObject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;

--- a/openapi-examples/helidon-basic-example/src/main/java/org/microprofileext/openapi/helidon/basic/example/GreetingProvider.java
+++ b/openapi-examples/helidon-basic-example/src/main/java/org/microprofileext/openapi/helidon/basic/example/GreetingProvider.java
@@ -15,8 +15,8 @@
  */
 package org.microprofileext.openapi.helidon.basic.example;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/openapi-examples/helidon-features-example/pom.xml
+++ b/openapi-examples/helidon-features-example/pom.xml
@@ -45,6 +45,11 @@
             <version>${lib.junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/GreetResource.java
+++ b/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/GreetResource.java
@@ -1,20 +1,20 @@
 package org.microprofileext.openapi.features.example;
 
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
-import javax.json.JsonObject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;

--- a/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/GreetingProvider.java
+++ b/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/GreetingProvider.java
@@ -1,9 +1,9 @@
 package org.microprofileext.openapi.features.example;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**

--- a/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/MyApplication.java
+++ b/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/MyApplication.java
@@ -1,8 +1,9 @@
 package org.microprofileext.openapi.features.example;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 import java.util.Set;
 
 @ApplicationScoped

--- a/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/UiApplication.java
+++ b/openapi-examples/helidon-features-example/src/main/java/org/microprofileext/openapi/features/example/UiApplication.java
@@ -1,11 +1,11 @@
 package org.microprofileext.openapi.features.example;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 import org.microprofileext.openapi.swaggerui.OpenApiUiService;
 import org.microprofileext.openapi.swaggerui.StaticResourcesService;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
 import java.util.Set;
 
 @ApplicationScoped

--- a/openapi-examples/pom.xml
+++ b/openapi-examples/pom.xml
@@ -15,13 +15,13 @@
     <description>Module containing OpenApi Extension examples</description>
 
     <properties>
-        <helidon.version>2.4.2</helidon.version>
-        <jackson.databind.version>2.13.1</jackson.databind.version>
+        <helidon.version>3.0.1</helidon.version>
+        <jackson.databind.version>2.13.4</jackson.databind.version>
         <lib.junit.version>5.7.0</lib.junit.version>
 
         <!-- plugins version -->
-        <helidon.plugin.version>2.3.3</helidon.plugin.version>
-        <jandex.plugin.version>1.0.6</jandex.plugin.version>
+        <helidon.plugin.version>3.0.1</helidon.plugin.version>
+        <jandex.plugin.version>1.2.3</jandex.plugin.version>
         <jar.plugin.version>3.0.2</jar.plugin.version>
         <dependency.plugin.version>3.1.2</dependency.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>

--- a/openapi-ui/pom.xml
+++ b/openapi-ui/pom.xml
@@ -15,7 +15,7 @@
     <description>A (swagger) UI for MicroProfile Open API</description>
     
     <properties>
-        <swagger-ui.version>3.25.0</swagger-ui.version>
+        <swagger-ui.version>4.14.2</swagger-ui.version>
         <swagger.ui.themes.version>3.0.0</swagger.ui.themes.version>
     </properties>
     

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/OpenApiUiService.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/OpenApiUiService.java
@@ -1,16 +1,16 @@
 package org.microprofileext.openapi.swaggerui;
 
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
-import javax.annotation.security.PermitAll;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 import lombok.extern.java.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/RequestInfo.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/RequestInfo.java
@@ -1,8 +1,8 @@
 package org.microprofileext.openapi.swaggerui;
 
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.UriInfo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
@@ -1,5 +1,9 @@
 package org.microprofileext.openapi.swaggerui;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -7,10 +11,6 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Response;
 import lombok.extern.java.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/Templates.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/Templates.java
@@ -1,5 +1,8 @@
 package org.microprofileext.openapi.swaggerui;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,13 +17,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.java.Log;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Helping with the templates (

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/WhiteLabel.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/WhiteLabel.java
@@ -1,17 +1,13 @@
 package org.microprofileext.openapi.swaggerui;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
 import lombok.Getter;
 import lombok.extern.java.Log;
 

--- a/openapi-ui/src/test/java/org/microprofileext/openapi/swaggerui/RequestInfoTest.java
+++ b/openapi-ui/src/test/java/org/microprofileext/openapi/swaggerui/RequestInfoTest.java
@@ -1,7 +1,8 @@
 package org.microprofileext.openapi.swaggerui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test all the types of paths

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         
-        <lombok.version>1.18.10</lombok.version>
-        <microProfile.version>3.2</microProfile.version>
+        <lombok.version>1.18.24</lombok.version>
+        <microProfile.version>5.0</microProfile.version>
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
Update parent dependencies to use Microprofile 5 and helidon examples to use helidon 3.0.1 to make use of the Jakarta EE and the new microprofile specification.

- changed microprofile version
- changed helidon mp version in examples
- changed imports to the new jakarta namespace
- added jackson dependency to helidon features example
- upgrade lombok, jandex, swagger-ui dependencies versions
- upgrade payara micro & openliberty dependencies in order to use the jakarta namespace
- Refactor producer class

```diff
+ OpenLiberty, Payara Micro, Helidon Examples will use Jakarta EE 9.1
- Thorntail example will become deprecated by using the latest openapi-ui version since it doesn't support the new jakarta namespace
```

An alternative might be to create a separate basic-thorntail-example module and configure it to use the 1.1.5 openapi-ui release.

fix for #36 