### PR TITLE
Upgrade Swagger UI to 5.18.2 and Handle 404 Errors Appropriately

### DIFF
--- a/openapi-examples/helidon-basic-example/pom.xml
+++ b/openapi-examples/helidon-basic-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.microprofile-ext.examples</groupId>
         <artifactId>openapi-examples</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openapi-helidon-se-example</artifactId>

--- a/openapi-examples/helidon-features-example/pom.xml
+++ b/openapi-examples/helidon-features-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.microprofile-ext.examples</groupId>
         <artifactId>openapi-examples</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openapi-helidon-features-example</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.microprofile-ext.openapi-ext</groupId>
             <artifactId>openapi-ui</artifactId>
-            <version>${project.version}</version>
+            <version>2.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.openapi</groupId>

--- a/openapi-examples/helidon-features-example/pom.xml
+++ b/openapi-examples/helidon-features-example/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.microprofile-ext.openapi-ext</groupId>
             <artifactId>openapi-ui</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.openapi</groupId>

--- a/openapi-ui/pom.xml
+++ b/openapi-ui/pom.xml
@@ -15,8 +15,8 @@
     <description>A (swagger) UI for MicroProfile Open API</description>
     
     <properties>
-        <swagger-ui.version>4.14.2</swagger-ui.version>
-        <swagger.ui.themes.version>3.0.0</swagger.ui.themes.version>
+        <swagger-ui.version>5.18.2</swagger-ui.version>
+        <swagger.ui.themes.version>3.0.1</swagger.ui.themes.version>
     </properties>
     
     <dependencies>
@@ -85,7 +85,7 @@
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
                         </artifactItem>
                         <artifactItem>
-                            <groupId>org.webjars.bower</groupId>
+                            <groupId>org.webjars.npm</groupId>
                             <artifactId>swagger-ui-themes</artifactId>
                             <version>${swagger.ui.themes.version}</version>
                             <type>jar</type>

--- a/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
+++ b/openapi-ui/src/main/java/org/microprofileext/openapi/swaggerui/StaticResourcesService.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -25,25 +26,30 @@ public class StaticResourcesService {
     @GET
     @Operation(hidden = true)
     public Response staticJsResources(@PathParam("path") final String path) {
-        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(String.format("META-INF/resources/%s", path));
-                BufferedReader buffer = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(String.format("META-INF/resources/%s", path))) {
+            if(Objects.isNull(inputStream)) {
+                log.log(Level.WARNING, "Could not find resource [{0}]", path);
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+            try ( BufferedReader buffer = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
                 StringWriter stringWriter = new StringWriter()) {
-            buffer.lines().forEach(stringWriter::write);
-
-            String response = stringWriter.toString();
-            if (response != null && !response.isEmpty()) {
-                Response.ResponseBuilder ret = Response.ok(response);
-                if (path.endsWith(".js")) {
-                    ret = ret.type("application/javascript");
+                buffer.lines().forEach(stringWriter::write);
+                String response = stringWriter.toString();
+                if (response != null && !response.isEmpty()) {
+                    Response.ResponseBuilder ret = Response.ok(response);
+                    if (path.endsWith(".js")) {
+                        ret = ret.type("application/javascript");
+                    }
+                    return ret.build();
+                } else {
+                    log.log(Level.WARNING, "The requested swagger file is empty!");
+                    return Response.noContent().build();
                 }
-                return ret.build();
             }
         } catch (IOException | NullPointerException ex) {
-            log.severe(ex.getMessage());
+            log.log(Level.SEVERE, "Failed to read the static Swagger file at path: {0}. Error details: {1}", new Object[]{path, ex.getMessage()});
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
         }
-        log.log(Level.WARNING, "Could not find resource [{0}]", path);
-        return Response.status(Response.Status.NOT_FOUND).build();
     }
     
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <microProfile.version>6.0</microProfile.version>
     </properties>
     


### PR DESCRIPTION
### Summary:
- Upgraded the Swagger UI and themes to the latest versions.
- Return a 404 status code when a file is unavailable instead of a 500 error.
  
### Details:
- The Swagger UI version has been upgraded from `4.14.2` to `5.18.2`
- The Swagger Themes version has been upgraded from `3.0.0` to `3.0.1` [ note we are moving from webjar to webjar.npm ]
- Logging improvements to handle file-not-found scenarios by logging a WARN instead of SEVERE.
- Return a 404 when a file is unavailable, rather than 500.
  
### Testing:
- Tested Helidon example and openapi UI works as expected.


![Screenshot 2025-01-18 162607](https://github.com/user-attachments/assets/d5e234ba-50de-4d84-936e-0d0158f73f44)

### Notes:
- No major functional changes, just improvements to the UI and error handling.
